### PR TITLE
configure: check for strlcat & strlcpy

### DIFF
--- a/configure
+++ b/configure
@@ -159,6 +159,20 @@ else
   COMPILER=gcc
 fi
 
+check_cc_snippet strlcat '#include <string.h>
+int test(int argc, char **argv) {
+  char dst[10];
+  strlcat("test", dst, sizeof(dst));
+  return 0;
+}'
+
+check_cc_snippet strlcpy '#include <string.h>
+int test(int argc, char **argv) {
+  char dst[10];
+  strlcpy("test", dst, sizeof(dst));
+  return 0;
+}'
+
 check_cc_snippet getloadavg '#include <stdlib.h>
 void test() { getloadavg(NULL,0); }'
 

--- a/src/tvh_string.h
+++ b/src/tvh_string.h
@@ -47,6 +47,7 @@ static inline const char *tvh_strbegins(const char *s1, const char *s2)
   return s1;
 }
 
+#ifndef ENABLE_STRLCPY
 static inline size_t strlcpy(char *dst, const char *src, size_t size)
 {
   size_t ret = strlen(src);
@@ -57,7 +58,9 @@ static inline size_t strlcpy(char *dst, const char *src, size_t size)
   }
   return ret;
 }
+#endif
 
+#ifndef ENABLE_STRLCAT
 static inline size_t strlcat(char *dst, const char *src, size_t count)
 {
   size_t dlen = strlen(dst);
@@ -72,6 +75,7 @@ static inline size_t strlcat(char *dst, const char *src, size_t count)
   dst[len] = '\0';
   return res;
 }
+#endif
 
 #define tvh_strlcatf(buf, size, ptr, fmt...) \
   do { int __r = snprintf((buf) + ptr, (size) - ptr, fmt); \


### PR DESCRIPTION
Building tvheadend with uclibc and musl fails:

src/tvh_string.h:50:22: error: static declaration of 'strlcpy' follows non-static declaration
 static inline size_t strlcpy(char *dst, const char *src, size_t size)

src/tvh_string.h:61:22: error: static declaration of 'strlcat' follows non-static declaration
 static inline size_t strlcat(char *dst, const char *src, size_t count)

because they provide strlcat & strlcpy:
https://sourceware.org/glibc/wiki/strlcpy

This patch adds configure checks and makes the implementation in
tvh_string.h optional, the configure log looks like this:

glibc
  checking for cc strlcat ...                       fail
  checking for cc strlcpy ...                       fail

musl
  checking for cc strlcat ...                       ok
  checking for cc strlcpy ...                       ok

uclibc
  checking for cc strlcat ...                       ok
  checking for cc strlcpy ...                       ok